### PR TITLE
Fix GZIP memory leak in `decompress` method

### DIFF
--- a/src/main/java/de/hamburgchimps/apple/notes/liberator/ByteUtils.java
+++ b/src/main/java/de/hamburgchimps/apple/notes/liberator/ByteUtils.java
@@ -13,11 +13,10 @@ public class ByteUtils {
     }
 
     public static byte[] decompress(byte[] data) throws IOException {
-        var inputBytes = new ByteArrayInputStream(data);
-        var gZipInput = new GZIPInputStream(inputBytes);
-        var outputBytes = new ByteArrayOutputStream();
-        gZipInput.transferTo(outputBytes);
-
-        return outputBytes.toByteArray();
+        try (var gZipInput = new GZIPInputStream(new ByteArrayInputStream(data));
+             var outputBytes = new ByteArrayOutputStream()) {
+            gZipInput.transferTo(outputBytes);
+            return outputBytes.toByteArray();
+        }
     }
 }


### PR DESCRIPTION
Use try-with-resources to close GZIP input stream so that the underlying native deflate buffer will be released.