### PR TITLE
add jbang catalog

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,10 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "apple-notes-liberator": {
+      "script-ref": "https://github.com/hamburgchimps/apple-notes-liberator/releases/latest/download/apple-notes-liberator.jar",
+      "java-agents": []
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
apple-notes-liberator can today be run directly with jbang using:

```
jbang https://github.com/hamburgchimps/apple-notes-liberator/releases/latest/download/apple-notes-liberator.jar
```

or even without having to install java nor jbang manually, you can do:

```
 curl -Ls https://sh.jbang.dev | bash -s - https://github.com/hamburgchimps/apple-notes-liberator/releases/latest/download/apple-notes-liberator.jar
```

This adds a jbang-catalog so you can use jbang to run apple-notes-liberator using an alias.

```bash
jbang apple-notes-liberator@hamburgchimps/apple-notes-liberator
```

NOTE: I would recommend creating a HamburgChimps/jbang-catalog repo which, if you put the same `jbang-catalog.json` you would be able to make the alias shorter:

```bash
jbang apple-notes-liberator@hamburgchimps
```

making the one-liner to run this on any (decent) OS:

```
 curl -Ls https://sh.jbang.dev | bash -s - apple-notes-liberator@hamburgchimps
```

if you do that then this PR is not needed.



